### PR TITLE
add random-access-test as dependency.

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,24 @@
 #!/usr/bin/env node
 const tape = require('tape')
+const randomTest = require('random-access-test')
 const ram = require('random-access-memory')
+const randomFile = require('random-access-file')
 const pauseWrap = require('.')
+
+var opts = {
+  writable: true,
+  reopen: true,
+  del: true,
+  truncate: false,
+  size: true,
+  content: false,
+  dir: '/tmp/random-pause-test'
+}
+
+randomTest(function (filename, opts2, callback) {
+  var storage = randomFile(opts.dir + '/' + filename, opts2)
+  callback(pauseWrap(storage))
+}, opts)
 
 function pauseRam (buffer) {
   return pauseWrap(ram(buffer))

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "random-access-storage": "^1.3.0"
   },
   "devDependencies": {
+    "random-access-test": "github:random-access-storage/random-access-test",
+    "random-access-file": "^2.1.3",
     "random-access-memory": "^3.0.0",
     "standard": "^12.0.1",
     "tape": "^4.9.1"


### PR DESCRIPTION
patch empty read issue.
patch destroy w/o callback issue.
bump version 1.0.1

**notice that `size` and `content` test suites are skipped. at this time they fail and I don't have the time to try and fix that part right now.**